### PR TITLE
Fix: random ParserException with routing rules engine

### DIFF
--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/RoutingGroupSelector.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/RoutingGroupSelector.java
@@ -37,23 +37,22 @@ public interface RoutingGroupSelector {
     RulesEngine rulesEngine = new DefaultRulesEngine();
     MVELRuleFactory ruleFactory = new MVELRuleFactory(new YamlRuleDefinitionReader());
 
-    return request -> {
-      try {
-        Rules rules = ruleFactory.createRules(
-            new FileReader(rulesConfigPath));
+    try {
+      Rules rules = ruleFactory.createRules(new FileReader(rulesConfigPath));
+
+      return request -> {
         Facts facts = new Facts();
         HashMap<String, String> result = new HashMap<String, String>();
         facts.put("request", request);
         facts.put("result", result);
         rulesEngine.fire(rules, facts);
         return result.get("routingGroup");
-      } catch (Exception e) {
-        Logger.log.error("Error opening rules configuration file,"
-            + " using routing group header as default.", e);
-        return Optional.ofNullable(request.getHeader(ROUTING_GROUP_HEADER))
-          .orElse(request.getHeader(ALTERNATE_ROUTING_GROUP_HEADER));
-      }
-    };
+      };
+    } catch (Exception e) {
+      Logger.log.error("Error opening rules configuration file,"
+          + " using routing group header as default.", e);
+      return byRoutingGroupHeader();
+    }
   }
 
   /**


### PR DESCRIPTION
I have seen sort of random queries being submitted to the default `adhoc` cluster instead of the intended cluster.

After a closer look, there was actually some exceptions being thrown i.e

```
! org.yaml.snakeyaml.parser.ParserException: while parsing a block mapping
! at org.yaml.snakeyaml.parser.ParserImpl$ParseBlockMappingKey.produce(ParserImpl.java:572)
! at org.yaml.snakeyaml.parser.ParserImpl$ParseBlockMappingFirstKey.produce(ParserImpl.java:552)
! at org.yaml.snakeyaml.parser.ParserImpl.peekEvent(ParserImpl.java:158)
! at org.yaml.snakeyaml.parser.ParserImpl.checkEvent(ParserImpl.java:148)
! at org.yaml.snakeyaml.composer.Composer.composeMappingNode(Composer.java:235)
! at org.yaml.snakeyaml.composer.Composer.composeNode(Composer.java:162)
! at org.yaml.snakeyaml.composer.Composer.composeKeyNode(Composer.java:253)
! at org.yaml.snakeyaml.composer.Composer.composeMappingChildren(Composer.java:244)
! at org.yaml.snakeyaml.composer.Composer.composeMappingNode(Composer.java:236)
! at org.yaml.snakeyaml.composer.Composer.composeNode(Composer.java:162)
! at org.yaml.snakeyaml.composer.Composer.getNode(Composer.java:95)
! at org.yaml.snakeyaml.constructor.BaseConstructor.getData(BaseConstructor.java:134)
! at org.yaml.snakeyaml.Yaml$1.next(Yaml.java:494)
```

The suspicion here is around reading/creating the rules on every request not being thread safe.