### PR TITLE
Add logback config

### DIFF
--- a/baseapp/pom.xml
+++ b/baseapp/pom.xml
@@ -40,11 +40,34 @@
             <artifactId>reflections</artifactId>
             <version>${reflections.version}</version>
         </dependency>
+
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
             <scope>provided</scope>
         </dependency>
+        <!-- ch.qos.logback.contrib.jackson.JacksonJsonFormatter -->
+        <dependency>
+            <groupId>ch.qos.logback.contrib</groupId>
+            <artifactId>logback-jackson</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- ch.qos.logback.contrib.json.classic.JsonLayout -->
+        <dependency>
+            <groupId>ch.qos.logback.contrib</groupId>
+            <artifactId>logback-json-classic</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- com.fasterxml.jackson.databind.ObjectMapper -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>

--- a/baseapp/src/main/resources/logback.xml
+++ b/baseapp/src/main/resources/logback.xml
@@ -6,8 +6,9 @@
                 <timestampFormatTimezoneId>Etc/UTC</timestampFormatTimezoneId>
 
                 <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
-                    <prettyPrint>true</prettyPrint>
+                    <prettyPrint>false</prettyPrint>
                 </jsonFormatter>
+                <appendLineSeparator>true</appendLineSeparator>
             </layout>
         </encoder>
     </appender>

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -85,6 +85,30 @@
             <artifactId>dropwizard-assets</artifactId>
             <version>${dropwizard.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+
+        <!-- ch.qos.logback.contrib.jackson.JacksonJsonFormatter -->
+        <dependency>
+            <groupId>ch.qos.logback.contrib</groupId>
+            <artifactId>logback-jackson</artifactId>
+        </dependency>
+
+        <!-- ch.qos.logback.contrib.json.classic.JsonLayout -->
+        <dependency>
+            <groupId>ch.qos.logback.contrib</groupId>
+            <artifactId>logback-json-classic</artifactId>
+        </dependency>
+
+        <!-- com.fasterxml.jackson.databind.ObjectMapper -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>

--- a/gateway-ha/src/main/resources/logback.xml
+++ b/gateway-ha/src/main/resources/logback.xml
@@ -4,6 +4,11 @@
             <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
                 <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSX</timestampFormat>
                 <timestampFormatTimezoneId>Etc/UTC</timestampFormatTimezoneId>
+
+                <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
+                    <prettyPrint>false</prettyPrint>
+                </jsonFormatter>
+                <appendLineSeparator>true</appendLineSeparator>
             </layout>
         </encoder>
     </appender>

--- a/gateway-ha/src/main/resources/logback.xml
+++ b/gateway-ha/src/main/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
+                <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSX</timestampFormat>
+                <timestampFormatTimezoneId>Etc/UTC</timestampFormatTimezoneId>
+            </layout>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="stdout"/>
+    </root>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -18,10 +18,12 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <jetty.version>9.4.48.v20220622</jetty.version>
-        <slf4j.version>1.7.25</slf4j.version>
         <lombok.version>1.18.22</lombok.version>
         <testng.version>6.10</testng.version>
         <mockwebserver.version>1.2.1</mockwebserver.version>
+
+        <logback.version>1.2.3</logback.version>
+        <logback.contrib.version>0.1.5</logback.contrib.version>
 
         <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
         <puppycrawl.tools.checkstyle.version>7.7</puppycrawl.tools.checkstyle.version>
@@ -46,12 +48,33 @@
                 <artifactId>jetty-servlet</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
+
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-simple</artifactId>
-                <version>${slf4j.version}</version>
-                <scope>provided</scope>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${logback.version}</version>
             </dependency>
+            <!-- ch.qos.logback.contrib.jackson.JacksonJsonFormatter -->
+            <dependency>
+                <groupId>ch.qos.logback.contrib</groupId>
+                <artifactId>logback-jackson</artifactId>
+                <version>${logback.contrib.version}</version>
+            </dependency>
+
+            <!-- ch.qos.logback.contrib.json.classic.JsonLayout -->
+            <dependency>
+                <groupId>ch.qos.logback.contrib</groupId>
+                <artifactId>logback-json-classic</artifactId>
+                <version>${logback.contrib.version}</version>
+            </dependency>
+
+            <!-- com.fasterxml.jackson.databind.ObjectMapper -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.9.5</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -20,6 +20,8 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <logback.version>1.4.7</logback.version>
+        <logback.contrib.version>0.1.5</logback.contrib.version>
     </properties>
 
 
@@ -37,10 +39,41 @@
             <artifactId>jetty-servlet</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
             <scope>provided</scope>
         </dependency>
+        <!-- ch.qos.logback.contrib.jackson.JacksonJsonFormatter -->
+        <dependency>
+            <groupId>ch.qos.logback.contrib</groupId>
+            <artifactId>logback-jackson</artifactId>
+            <version>${logback.contrib.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- ch.qos.logback.contrib.json.classic.JsonLayout -->
+        <dependency>
+            <groupId>ch.qos.logback.contrib</groupId>
+            <artifactId>logback-json-classic</artifactId>
+            <version>${logback.contrib.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- com.fasterxml.jackson.databind.ObjectMapper -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.9.5</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.25</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -20,8 +20,6 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <logback.version>1.4.7</logback.version>
-        <logback.contrib.version>0.1.5</logback.contrib.version>
     </properties>
 
 
@@ -38,17 +36,16 @@
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
         </dependency>
+
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
             <scope>provided</scope>
         </dependency>
         <!-- ch.qos.logback.contrib.jackson.JacksonJsonFormatter -->
         <dependency>
             <groupId>ch.qos.logback.contrib</groupId>
             <artifactId>logback-jackson</artifactId>
-            <version>${logback.contrib.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -56,7 +53,6 @@
         <dependency>
             <groupId>ch.qos.logback.contrib</groupId>
             <artifactId>logback-json-classic</artifactId>
-            <version>${logback.contrib.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -64,13 +60,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.5</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
             <scope>provided</scope>
         </dependency>
 

--- a/proxyserver/src/main/java/com/lyft/data/proxyserver/ProxyHandler.java
+++ b/proxyserver/src/main/java/com/lyft/data/proxyserver/ProxyHandler.java
@@ -68,7 +68,11 @@ public class ProxyHandler {
       Enumeration<String> headers = request.getHeaderNames();
       while (headers.hasMoreElements()) {
         String header = headers.nextElement();
-        log.debug(header + "->" + request.getHeader(header));
+        if (header.equalsIgnoreCase("authorization")) {
+          log.debug(header + "-> [REDACTED]");
+        } else {
+          log.debug(header + "->" + request.getHeader(header));
+        }
       }
     }
   }

--- a/proxyserver/src/main/resources/logback.xml
+++ b/proxyserver/src/main/resources/logback.xml
@@ -1,0 +1,18 @@
+<configuration>
+    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
+                <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSX</timestampFormat>
+                <timestampFormatTimezoneId>Etc/UTC</timestampFormatTimezoneId>
+
+                <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
+                    <prettyPrint>true</prettyPrint>
+                </jsonFormatter>
+            </layout>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="stdout"/>
+    </root>
+</configuration>

--- a/proxyserver/src/main/resources/logback.xml
+++ b/proxyserver/src/main/resources/logback.xml
@@ -6,8 +6,9 @@
                 <timestampFormatTimezoneId>Etc/UTC</timestampFormatTimezoneId>
 
                 <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
-                    <prettyPrint>true</prettyPrint>
+                    <prettyPrint>false</prettyPrint>
                 </jsonFormatter>
+                <appendLineSeparator>true</appendLineSeparator>
             </layout>
         </encoder>
     </appender>

--- a/proxyserver/src/test/resources/logback.xml
+++ b/proxyserver/src/test/resources/logback.xml
@@ -1,0 +1,18 @@
+<configuration>
+    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
+                <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSX</timestampFormat>
+                <timestampFormatTimezoneId>Etc/UTC</timestampFormatTimezoneId>
+
+                <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
+                    <prettyPrint>true</prettyPrint>
+                </jsonFormatter>
+            </layout>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="stdout"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Add logback config and redact Authorization header in debug log.

Loggs look like:
```
{"timestamp":"2023-05-15T09:52:05.128Z","level":"DEBUG","thread":"qtp843959601-24","logger":"org.eclipse.jetty.io.ManagedSelector","message":"updateable 1","context":"default"}
{"timestamp":"2023-05-15T09:52:05.129Z","level":"DEBUG","thread":"qtp843959601-24","logger":"org.eclipse.jetty.io.ManagedSelector","message":"update org.eclipse.jetty.io.ManagedSelector$Start@23940f86","context":"default"}
{"timestamp":"2023-05-15T09:52:05.129Z","level":"DEBUG","thread":"qtp843959601-24","logger":"org.eclipse.jetty.io.ManagedSelector","message":"updates 0","context":"default"}
{"timestamp":"2023-05-15T09:52:05.129Z","level":"DEBUG","thread":"main","logger":"org.eclipse.jetty.util.component.AbstractLifeCycle","message":"STARTED @2263ms ManagedSelector@5d01ea21{STARTED} id=0 keys=0 selected=0 updates=0","context":"default"}
```