### PR TITLE
Redact auth token in debug log

### DIFF
--- a/proxyserver/src/main/java/com/lyft/data/proxyserver/ProxyHandler.java
+++ b/proxyserver/src/main/java/com/lyft/data/proxyserver/ProxyHandler.java
@@ -68,7 +68,11 @@ public class ProxyHandler {
       Enumeration<String> headers = request.getHeaderNames();
       while (headers.hasMoreElements()) {
         String header = headers.nextElement();
-        log.debug(header + "->" + request.getHeader(header));
+        if (header.equalsIgnoreCase("authorization")) {
+          log.debug(header + "-> [REDACTED]");
+        } else {
+          log.debug(header + "->" + request.getHeader(header));
+        }
       }
     }
   }


### PR DESCRIPTION
Authorization token is currently seen in debug log, it needs to be redacted.