### PR TITLE
Source HTTP Proxy properties from RequestRouterConfiguration

### DIFF
--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/config/RequestRouterConfiguration.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/config/RequestRouterConfiguration.java
@@ -22,4 +22,10 @@ public class RequestRouterConfiguration {
 
   // assume https if forwarded by a proxy
   private boolean forwardedHttps;
+
+  // Set custom sizes for HTTP connection buffers
+  private int requestHeaderSize;
+  private int responseHeaderSize;
+  private int requestBufferSize;
+  private int responseBufferSize;
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/HaGatewayProviderModule.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/HaGatewayProviderModule.java
@@ -82,6 +82,11 @@ public class HaGatewayProviderModule extends AppModule<HaGatewayConfiguration, E
       routerProxyConfig.setKeystorePass(routerConfiguration.getKeystorePass());
       routerProxyConfig.setForwardKeystore(routerConfiguration.isForwardKeystore());
       routerProxyConfig.setPreserveHost("false");
+      routerProxyConfig.setResponseHeaderSize(routerConfiguration.getResponseHeaderSize());
+      routerProxyConfig.setResponseBufferSize(routerConfiguration.getResponseBufferSize());
+      routerProxyConfig.setRequestHeaderSize(routerConfiguration.getRequestHeaderSize());
+      routerProxyConfig.setRequestBufferSize(routerConfiguration.getRequestBufferSize());
+
       ProxyHandler proxyHandler = getProxyHandler();
       gateway = new ProxyServer(routerProxyConfig, proxyHandler);
     }


### PR DESCRIPTION
HaGatewayLauncher is the gateway entrypoint loading the HaGatewayProviderModule. This module initializes the proxy server by reading properties from RequestRouterConfiguration.